### PR TITLE
Add Python voice assistant prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
 .DS_Store
+red_assistant/logs/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@
 - "подарок девушке до 30 евро"
 
 Проект использует HTML + JS и подходит для запуска минимального MVP.
+
+---
+
+## Red Assistant
+
+В папке `red_assistant` находится прототип голосового ассистента на Python. Он использует SpeechRecognition для распознавания речи, простые функции для выполнения команд и свободную модель `distilgpt2` из библиотеки `transformers` для генерации ответов. Все ответы и ошибки пишутся в файл `red_assistant/logs/assistant.log`.
+
+### Запуск
+
+```bash
+pip install -r requirements.txt
+python -m red_assistant
+```

--- a/red_assistant/README.md
+++ b/red_assistant/README.md
@@ -1,0 +1,16 @@
+# Red Assistant
+
+Python prototype of a voice controlled assistant. It uses `SpeechRecognition` for microphone input, executes simple desktop commands and generates answers with a free neural network (the `distilgpt2` model from the `transformers` library). All responses and errors are logged to `logs/assistant.log`.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the assistant:
+   ```bash
+   python -m red_assistant
+   ```
+
+The assistant listens to the microphone. Try phrases like "open browser" or "create file".

--- a/red_assistant/__init__.py
+++ b/red_assistant/__init__.py
@@ -1,0 +1,5 @@
+"""Voice controlled assistant using open-source models."""
+
+from .main import main
+
+__all__ = ['main']

--- a/red_assistant/ai_model.py
+++ b/red_assistant/ai_model.py
@@ -1,0 +1,16 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+from .logger import logger
+
+MODEL_NAME = 'distilgpt2'
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+
+
+def generate_response(prompt: str, max_length: int = 50) -> str:
+    inputs = tokenizer.encode(prompt, return_tensors='pt')
+    with torch.no_grad():
+        outputs = model.generate(inputs, max_length=max_length, do_sample=True)
+    text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return text

--- a/red_assistant/command_executor.py
+++ b/red_assistant/command_executor.py
@@ -1,0 +1,18 @@
+import os
+import webbrowser
+from .logger import logger
+
+
+def parse_and_execute(command: str) -> bool:
+    command_lower = command.lower()
+    if 'open browser' in command_lower or 'открой браузер' in command_lower:
+        logger.info('Opening default web browser')
+        webbrowser.open('https://www.google.com')
+        return True
+    if 'create file' in command_lower or 'создай файл' in command_lower:
+        filename = 'new_file.txt'
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write('')
+        logger.info('Created file %s', filename)
+        return True
+    return False

--- a/red_assistant/logger.py
+++ b/red_assistant/logger.py
@@ -1,0 +1,18 @@
+import logging
+import os
+
+LOG_DIR = os.path.join(os.path.dirname(__file__), 'logs')
+os.makedirs(LOG_DIR, exist_ok=True)
+
+LOG_FILE = os.path.join(LOG_DIR, 'assistant.log')
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE, encoding='utf-8'),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger('red_assistant')

--- a/red_assistant/main.py
+++ b/red_assistant/main.py
@@ -1,0 +1,25 @@
+from .voice_input import listen
+from .command_executor import parse_and_execute
+from .ai_model import generate_response
+from .logger import logger
+
+
+def main():
+    logger.info('Red Assistant started')
+    try:
+        while True:
+            text = listen()
+            if not text:
+                continue
+            logger.info('User said: %s', text)
+            if parse_and_execute(text):
+                continue
+            response = generate_response(text)
+            logger.info('Assistant: %s', response)
+            print(response)
+    except KeyboardInterrupt:
+        logger.info('Assistant stopped by user')
+
+
+if __name__ == '__main__':
+    main()

--- a/red_assistant/voice_input.py
+++ b/red_assistant/voice_input.py
@@ -1,0 +1,16 @@
+import speech_recognition as sr
+from .logger import logger
+
+def listen() -> str:
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        print('Listening...')
+        audio = recognizer.listen(source)
+    try:
+        text = recognizer.recognize_google(audio, language='ru-RU')
+        return text
+    except sr.UnknownValueError:
+        logger.error('Could not understand audio')
+    except sr.RequestError as exc:
+        logger.error('Speech recognition error: %s', exc)
+    return ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+SpeechRecognition
+transformers
+torch
+pyaudio


### PR DESCRIPTION
## Summary
- add new `red_assistant` Python package implementing a speech-controlled assistant
- support simple commands like opening a browser or creating a file
- integrate open-source `distilgpt2` model from `transformers` for responses
- log assistant activity to `red_assistant/logs/assistant.log`
- include usage instructions and dependencies

## Testing
- `python -m py_compile red_assistant/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68713c23c51c83298bdb8808327a7351